### PR TITLE
servicebus: expose 'label' in message panel

### DIFF
--- a/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/AzAmqpMessage.java
+++ b/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/AzAmqpMessage.java
@@ -35,6 +35,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     private static final String PARTITION_KEY = "Message.partitionKey"; //$NON-NLS$
     private static final String CUSTOM_PROPERTIES = "Message.customProperties"; //$NON-NLS$
     private static final String CONTENT_TYPE = "Message.contentType"; //$NON-NLS$
+    private static final String LABEL = "Message.label"; //$NON-NLS$
 
     public AzAmqpMessage() {
     }
@@ -42,8 +43,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Create a new Message with the specified system properties and custom properties
      *
-     * @param messageType
-     *            type of message
+     * @param messageType type of message
      */
 
     public AzAmqpMessage(String messageType) {
@@ -54,13 +54,13 @@ public class AzAmqpMessage extends AbstractTestElement {
         setProperty(new StringProperty(GROUP_ID, ""));
         setProperty(new StringProperty(CUSTOM_PROPERTIES, ""));
         setProperty(new StringProperty(CONTENT_TYPE, ""));
+        setProperty(new StringProperty(LABEL, ""));
     }
 
     /**
      * Set the message type of the Message.
      *
-     * @param newMessageType
-     *            the new message type
+     * @param newMessageType the new message type
      */
     public void setMessageType(String newMessageType) {
         setProperty(new StringProperty(MESSAGE_TYPE, newMessageType));
@@ -78,8 +78,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the message of the Message.
      *
-     * @param newMessage
-     *            the new message
+     * @param newMessage the new message
      */
     public void setMessage(String newMessage) {
         setProperty(new StringProperty(MESSAGE, newMessage));
@@ -97,8 +96,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the message Id of the Message.
      *
-     * @param newMessageId
-     *            the new message Id
+     * @param newMessageId the new message Id
      */
     public void setMessageId(String newMessageId) {
         setProperty(new StringProperty(MESSAGE_ID, newMessageId));
@@ -116,8 +114,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the group Id of the Message.
      *
-     * @param newGroupId
-     *            the new group Id
+     * @param newGroupId the new group Id
      */
     public void setGroupId(String newGroupId) {
         setProperty(new StringProperty(GROUP_ID, newGroupId));
@@ -135,8 +132,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the partition key of the Message.
      *
-     * @param newPartitionKey
-     *            the new message Id
+     * @param newPartitionKey the new message Id
      */
     public void setPartitionKey(String newPartitionKey) {
         setProperty(new StringProperty(PARTITION_KEY, newPartitionKey));
@@ -154,8 +150,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the custom properties of the Message.
      *
-     * @param newCustomProperties
-     *            the new custom properties
+     * @param newCustomProperties the new custom properties
      */
     public void setCustomProperties(String newCustomProperties) {
         setProperty(new StringProperty(CUSTOM_PROPERTIES, newCustomProperties));
@@ -173,8 +168,7 @@ public class AzAmqpMessage extends AbstractTestElement {
     /**
      * Set the content type of the Message.
      *
-     * @param contentType
-     *            the new content type
+     * @param contentType the new content type
      */
     public void setContentType(String contentType) {
         setProperty(new StringProperty(CONTENT_TYPE, contentType));
@@ -187,6 +181,14 @@ public class AzAmqpMessage extends AbstractTestElement {
      */
     public String getContentType() {
         return getPropertyAsString(CONTENT_TYPE);
+    }
+
+    public String getLabel() {
+        return getPropertyAsString(LABEL);
+    }
+
+    public void setLabel(String label) {
+        setProperty(new StringProperty(LABEL, label));
     }
 
 }

--- a/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/gui/AzAmqpMessagesPanel.java
+++ b/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/gui/AzAmqpMessagesPanel.java
@@ -88,6 +88,7 @@ public class AzAmqpMessagesPanel extends AbstractSamplerGui implements ActionLis
         COLUMN_NAMES.put("GROUP_ID", "group Id"); //$NON-NLS-1$
         COLUMN_NAMES.put("CUSTOM_PROPERTIES", "custom properties"); //$NON-NLS-1$
         COLUMN_NAMES.put("CONTENT_TYPE", "content type"); //$NON-NLS-1$
+        COLUMN_NAMES.put("LABEL", "label"); //$NON-NLS-1$
     }
 
     public AzAmqpMessagesPanel() {

--- a/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/gui/AzAmqpMessagesPanel.java
+++ b/plugins/protocol/amqp/src/main/java/jp/co/pnop/jmeter/protocol/amqp/sampler/gui/AzAmqpMessagesPanel.java
@@ -88,7 +88,7 @@ public class AzAmqpMessagesPanel extends AbstractSamplerGui implements ActionLis
         COLUMN_NAMES.put("GROUP_ID", "group Id"); //$NON-NLS-1$
         COLUMN_NAMES.put("CUSTOM_PROPERTIES", "custom properties"); //$NON-NLS-1$
         COLUMN_NAMES.put("CONTENT_TYPE", "content type"); //$NON-NLS-1$
-        COLUMN_NAMES.put("LABEL", "label"); //$NON-NLS-1$
+        COLUMN_NAMES.put("LABEL", "label/subject"); //$NON-NLS-1$
     }
 
     public AzAmqpMessagesPanel() {

--- a/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/AzServiceBusSampler.java
+++ b/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/AzServiceBusSampler.java
@@ -72,9 +72,9 @@ public class AzServiceBusSampler extends AbstractSampler implements TestStateLis
     private static final Logger log = LoggerFactory.getLogger(AzServiceBusSampler.class);
 
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
-            Arrays.asList(
-                    "org.apache.jmeter.config.gui.SimpleConfigGui"
-            )
+        Arrays.asList(
+            "org.apache.jmeter.config.gui.SimpleConfigGui"
+        )
     );
 
     public static final String CREATE_TRANSACTION = "createTransaction";
@@ -293,15 +293,15 @@ public class AzServiceBusSampler extends AbstractSampler implements TestStateLis
                 String label = msg.getLabel();
                 if (!label.isEmpty()) {
                     serviceBusMessage.setSubject(label);
-                    requestBody = requestBody.concat("\n").concat("Label: ").concat(label);
+                    requestBody = requestBody.concat("\n").concat("Label/Subject: ").concat(label);
                 }
 
                 batch.tryAddMessage(serviceBusMessage);
                 bodyBytes += serviceBusMessage.getBody().toBytes().length;
 
                 requestBody = requestBody.concat("\n")
-                        .concat("Message type: ").concat(msg.getMessageType()).concat("\n")
-                        .concat("Body: ").concat(msg.getMessage());
+                    .concat("Message type: ").concat(msg.getMessageType()).concat("\n")
+                    .concat("Body: ").concat(msg.getMessage());
             }
 
             bytes = batch.getSizeInBytes();

--- a/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/gui/AzServiceBusMessagesPanel.java
+++ b/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/gui/AzServiceBusMessagesPanel.java
@@ -20,8 +20,8 @@ public class AzServiceBusMessagesPanel extends AzAmqpMessagesPanel {
         tableModel = new ObjectTableModel(
             new String[] { COLUMN_NAMES.get("MESSAGE_TYPE"), COLUMN_NAMES.get("MESSAGE"), COLUMN_NAMES.get("MESSAGE_ID"), "session Id", "partition key", COLUMN_NAMES.get("CONTENT_TYPE"), COLUMN_NAMES.get("CUSTOM_PROPERTIES"), COLUMN_NAMES.get("LABEL") },
             AzAmqpMessage.class,
-            new Functor[] { new Functor("getMessageType"), new Functor("getMessage"), new Functor("getMessageId"), new Functor("getGroupId"), new Functor("getPartitionKey"), new Functor("getContentType"), new Functor("getCustomProperties"), new Functor("getLabel") },
-            new Functor[] { new Functor("setMessageType"), new Functor("setMessage"), new Functor("setMessageId"), new Functor("setGroupId"), new Functor("setPartitionKey"), new Functor("setContentType"), new Functor("setCustomProperties"), new Functor("setLabel") },
+            new Functor[] { new Functor("getMessageType"), new Functor("getMessage"), new Functor("getMessageId"), new Functor("getGroupId"), new Functor("getPartitionKey"), new Functor("getContentType"), new Functor("getLabel"), new Functor("getCustomProperties") },
+            new Functor[] { new Functor("setMessageType"), new Functor("setMessage"), new Functor("setMessageId"), new Functor("setGroupId"), new Functor("setPartitionKey"), new Functor("setContentType"), new Functor("setLabel"), new Functor("setCustomProperties") },
             new Class[] { String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class }
         );
     }

--- a/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/gui/AzServiceBusMessagesPanel.java
+++ b/plugins/protocol/servicebus/src/main/java/jp/co/pnop/jmeter/protocol/azureservicebus/sampler/gui/AzServiceBusMessagesPanel.java
@@ -18,11 +18,11 @@ public class AzServiceBusMessagesPanel extends AzAmqpMessagesPanel {
     @Override
     protected void initializeTableModel() {
         tableModel = new ObjectTableModel(
-            new String[] { COLUMN_NAMES.get("MESSAGE_TYPE"), COLUMN_NAMES.get("MESSAGE"), COLUMN_NAMES.get("MESSAGE_ID"), "session Id", "partition key", COLUMN_NAMES.get("CONTENT_TYPE"), COLUMN_NAMES.get("CUSTOM_PROPERTIES") },
+            new String[] { COLUMN_NAMES.get("MESSAGE_TYPE"), COLUMN_NAMES.get("MESSAGE"), COLUMN_NAMES.get("MESSAGE_ID"), "session Id", "partition key", COLUMN_NAMES.get("CONTENT_TYPE"), COLUMN_NAMES.get("CUSTOM_PROPERTIES"), COLUMN_NAMES.get("LABEL") },
             AzAmqpMessage.class,
-            new Functor[] { new Functor("getMessageType"), new Functor("getMessage"), new Functor("getMessageId"), new Functor("getGroupId"), new Functor("getPartitionKey"), new Functor("getContentType"), new Functor("getCustomProperties") },
-            new Functor[] { new Functor("setMessageType"), new Functor("setMessage"), new Functor("setMessageId"), new Functor("setGroupId"), new Functor("setPartitionKey"), new Functor("setContentType"), new Functor("setCustomProperties") },
-            new Class[] { String.class, String.class, String.class, String.class, String.class, String.class, String.class }
+            new Functor[] { new Functor("getMessageType"), new Functor("getMessage"), new Functor("getMessageId"), new Functor("getGroupId"), new Functor("getPartitionKey"), new Functor("getContentType"), new Functor("getCustomProperties"), new Functor("getLabel") },
+            new Functor[] { new Functor("setMessageType"), new Functor("setMessage"), new Functor("setMessageId"), new Functor("setGroupId"), new Functor("setPartitionKey"), new Functor("setContentType"), new Functor("setCustomProperties"), new Functor("setLabel") },
+            new Class[] { String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class }
         );
     }
 


### PR DESCRIPTION
this is a small new feature to enable users to set label (subject) to the message they publish, if no data is specified as label then empty is asigned